### PR TITLE
getting customer_id from the register-card payload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 1.0.0a10 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Be able to update customer when calling @register-card, customer_id
+  can be passed as a parameter
 
 
 1.0.0a9 (2021-11-24)

--- a/guillotina_stripe/product.py
+++ b/guillotina_stripe/product.py
@@ -82,7 +82,7 @@ async def register_paymentmethod(context, request):
 
     bhr.billing_email = billing_email
     util: StripePayUtility = get_utility(IStripePayUtility)
-    customer = await util.set_customer(billing_email)
+    customer = await util.set_customer(billing_email, payload.get("customer_id", None))
     customerid = customer.get("id", None)
 
     taxid = payload.get('tax')

--- a/guillotina_stripe/subscription.py
+++ b/guillotina_stripe/subscription.py
@@ -82,7 +82,7 @@ async def register_paymentmethod(context, request):
 
     bhr.billing_email = billing_email
     util: StripePayUtility = get_utility(IStripePayUtility)
-    customer = await util.set_customer(billing_email)
+    customer = await util.set_customer(billing_email, payload.get("customer_id", None))
     taxid = payload.get("tax")
 
     customerid = customer.get("id", None)


### PR DESCRIPTION
Now, everytime we call @register-card, a new customer is created.
Be able to pass customer_id to update the costumer instead of creating always a new one
https://stripe.com/docs/api/customers/update